### PR TITLE
Fix ternary

### DIFF
--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -143,7 +143,7 @@ function getRelatedItems (ids, relatedItems, include) {
   return relatedItems.reduce((items, currentItem) => {
     ids.forEach(id => {
       id = typeof id === 'number' ? id : id.toString()
-      const currentId = typeof currentItem[keyThere] === 'number' ? currentItem[keyThere] : currentItem[keyThere].toString()
+      const currentId = typeof currentItem[keyThere] === 'number' ? currentItem[keyThere].toString() : currentItem[keyThere]
       if (asArray) {
         if (currentId.includes(id)) {
           items.push(currentItem)


### PR DESCRIPTION
The current version created an error that `currentId.includes` is not a function as you can't use it on numbers. The fix converts the id to a string if it is a number, instead of effectively doing nothing.