### PR TITLE
Allow populating on nested arrays of objects

### DIFF
--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -143,9 +143,25 @@ function getRelatedItems (ids, relatedItems, include) {
   return relatedItems.reduce((items, currentItem) => {
     ids.forEach(id => {
       id = typeof id === 'number' ? id : id.toString()
-      const keyThereVal = getByDot(currentItem, keyThere)
-      const currentId = typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
-      if (asArray) {
+      let currentId
+      // Allow populating on nested array of objects like key[0].name, key[1].name
+      // If keyThere includes a dot, we're looking for a nested prop. This checks if that nested prop is an array.
+      // If it's an array, we assume it to be an array of objects.
+      // It splits the key only on the first dot which allows populating on nested keys inside the array of objects.
+      if (keyThere.includes('.') && Array.isArray(currentItem[keyThere.slice(0, keyThere.indexOf('.'))])) {
+        // The name of the array is everything leading up to the first dot.
+        const arrayName = keyThere.split('.')[0]
+        // The rest will be handed to getByDot as the path to the prop
+        const nestedProp = keyThere.slice(keyThere.indexOf('.') + 1)
+        // Map over the array to grab each nestedProp's value.
+        currentId = currentItem[arrayName].map(nestedItem => {
+          const keyThereVal = getByDot(nestedItem, nestedProp)
+          return typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
+        })
+      } else {
+        const keyThereVal = getByDot(currentItem, keyThere)
+        currentId = typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
+      } if (asArray) {
         if (currentId.includes(id)) {
           items.push(currentItem)
         }


### PR DESCRIPTION
Allow populating on nested array of objects like key[0].name, key[1].name

If keyThere includes a dot, we're looking for a nested prop. This checks if that nested prop is an array.

If it's an array, we assume it to be an array of objects.

It splits the key only on the first dot which allows populating on nested keys inside the array of objects.