### PR TITLE
[Fix] keyThereVal: number => string conversion

### DIFF
--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -143,7 +143,7 @@ function getRelatedItems (ids, relatedItems, include) {
   ids = [].concat(ids || [])
   return relatedItems.reduce((items, currentItem) => {
     ids.forEach(id => {
-      id = typeof id === 'number' ? id : id.toString()
+      id = typeof id !== 'number' ? id : id.toString()
       let currentId
       // Allow populating on nested array of objects like key[0].name, key[1].name
       // If keyThere includes a dot, we're looking for a nested prop. This checks if that nested prop is an array.
@@ -157,11 +157,11 @@ function getRelatedItems (ids, relatedItems, include) {
         // Map over the array to grab each nestedProp's value.
         currentId = currentItem[arrayName].map(nestedItem => {
           const keyThereVal = getByDot(nestedItem, nestedProp)
-          return typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
+          return typeof keyThereVal !== 'number' ? keyThereVal : keyThereVal.toString()
         })
       } else {
         const keyThereVal = getByDot(currentItem, keyThere)
-        currentId = typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
+        currentId = typeof keyThereVal !== 'number' ? keyThereVal : keyThereVal.toString()
       } if (asArray) {
         if (currentId.includes(id)) {
           items.push(currentItem)

--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -143,7 +143,7 @@ function getRelatedItems (ids, relatedItems, include) {
   ids = [].concat(ids || [])
   return relatedItems.reduce((items, currentItem) => {
     ids.forEach(id => {
-      id = typeof id !== 'number' ? id : id.toString()
+      id = typeof id === 'number' ? id : id.toString()
       let currentId
       // Allow populating on nested array of objects like key[0].name, key[1].name
       // If keyThere includes a dot, we're looking for a nested prop. This checks if that nested prop is an array.
@@ -157,11 +157,11 @@ function getRelatedItems (ids, relatedItems, include) {
         // Map over the array to grab each nestedProp's value.
         currentId = currentItem[arrayName].map(nestedItem => {
           const keyThereVal = getByDot(nestedItem, nestedProp)
-          return typeof keyThereVal !== 'number' ? keyThereVal : keyThereVal.toString()
+          return typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
         })
       } else {
         const keyThereVal = getByDot(currentItem, keyThere)
-        currentId = typeof keyThereVal !== 'number' ? keyThereVal : keyThereVal.toString()
+        currentId = typeof keyThereVal === 'number' ? [keyThereVal] : [keyThereVal.toString()]
       } if (asArray) {
         if (currentId.includes(id)) {
           items.push(currentItem)


### PR DESCRIPTION
This is needed for feathers adapters that use a number as id instead of string (feathers-sequelize)