### PR TITLE
fix: working with numbers & strings as id

### DIFF
--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -77,12 +77,12 @@ module.exports = function (options) {
         if (keyHere) {
           if (Array.isArray(keyHere)) {
             if (!requiredKeyMappings[key].asArray) {
-              mapData(byKeyHere, key, keyHere[0], current)
+              mapDataWithId(byKeyHere, key, keyHere[0], current)
             } else {
-              keyHere.forEach(hereKey => mapData(byKeyHere, key, hereKey, current))
+              keyHere.forEach(hereKey => mapDataWithId(byKeyHere, key, hereKey, current))
             }
           } else {
-            mapData(byKeyHere, key, keyHere, current)
+            mapDataWithId(byKeyHere, key, keyHere, current)
           }
         }
       })
@@ -104,7 +104,9 @@ module.exports = function (options) {
     // }
 
     const paramSets = includes.map(i => {
-      const keysHere = Object.keys(dataMap[i.keyHere]) || []
+      const keyVals = dataMap[i.keyHere]
+      let keysHere = Object.keys(keyVals) || []
+      keysHere = keysHere.map(k => keyVals[k].key)
 
       return { query: { [i.keyThere]: { $in: keysHere } } }
     })
@@ -143,7 +145,7 @@ function getRelatedItems (ids, relatedItems, include) {
   ids = [].concat(ids || [])
   return relatedItems.reduce((items, currentItem) => {
     ids.forEach(id => {
-      id = typeof id === 'number' ? id : id.toString()
+      // id = typeof id === 'number' ? id.toString() : id
       let currentId
       // Allow populating on nested array of objects like key[0].name, key[1].name
       // If keyThere includes a dot, we're looking for a nested prop. This checks if that nested prop is an array.
@@ -157,17 +159,18 @@ function getRelatedItems (ids, relatedItems, include) {
         // Map over the array to grab each nestedProp's value.
         currentId = currentItem[arrayName].map(nestedItem => {
           const keyThereVal = getByDot(nestedItem, nestedProp)
-          return typeof keyThereVal === 'number' ? keyThereVal : keyThereVal.toString()
+          return keyThereVal
         })
       } else {
         const keyThereVal = getByDot(currentItem, keyThere)
-        currentId = typeof keyThereVal === 'number' ? [keyThereVal] : [keyThereVal.toString()]
-      } if (asArray) {
-        if (currentId.includes(id)) {
+        currentId = keyThereVal
+      }
+      if (asArray) {
+        if ((Array.isArray(currentId) && currentId.includes(id)) || currentId === id) {
           items.push(currentItem)
         }
       } else {
-        if (currentId.includes(id)) {
+        if (currentId === id) {
           items = currentItem
         }
       }
@@ -176,8 +179,11 @@ function getRelatedItems (ids, relatedItems, include) {
   }, asArray ? [] : {})
 }
 
-function mapData (byKeyHere, key, keyHere, current) {
-  byKeyHere[key][keyHere] = byKeyHere[key][keyHere] || []
-  byKeyHere[key][keyHere].push(current)
+function mapDataWithId (byKeyHere, key, keyHere, current) {
+  byKeyHere[key][keyHere] = byKeyHere[key][keyHere] || {
+    key: keyHere,
+    vals: []
+  }
+  byKeyHere[key][keyHere].vals.push(current)
   return byKeyHere
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,26 +73,26 @@
       "integrity": "sha512-r+n31iZ/B5Rl1mLkC9/S20UI445MdkZvE3VBmjupep2t8OuyTYHPkFEgR25HY6khH+RothK1VL3B5eumk9N2QQ=="
     },
     "@feathersjs/adapter-commons": {
-      "version": "4.0.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-4.0.0-pre.5.tgz",
-      "integrity": "sha512-ppfiKhV9gOpQye9LpoQ5zdMwO8/49EGLcQMGZR3SRz1lNQmVj/d1q3/6B9hKiAFJkP1EX2JMZbMNFPyTisP6ww==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/adapter-commons/-/adapter-commons-4.5.2.tgz",
+      "integrity": "sha512-7NF4WO/R0OOZo6/mPnMml4Hz+Ynr0JMCp4TDO6JIf3ITAwc78A7b6jrORw1sw3Cq3hkD0sC342sk7mRk3BwPDg==",
       "dev": true,
       "requires": {
-        "@feathersjs/commons": "^4.0.0-pre.5",
-        "@feathersjs/errors": "^4.0.0-pre.5",
-        "@feathersjs/feathers": "^4.0.0-pre.5"
+        "@feathersjs/commons": "^4.5.2",
+        "@feathersjs/errors": "^4.5.2",
+        "@feathersjs/feathers": "^4.5.2"
       }
     },
     "@feathersjs/commons": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.0.0.tgz",
-      "integrity": "sha512-hyCLse4RiNt7WLPQ0KSudjoVnwiRykhYzIZdtDon9i2usPaoYkFw/fEYZrkE5HVB+sUTwphZoZ1oOntRk1MShg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.5.3.tgz",
+      "integrity": "sha512-LsiZ0jxh13TT6SOrDq5VYtdBCv0Vdvu4a5Wei/Dvd/daZHX6ERuH6iQtfh2f5hFwuydtd+Ch/2GlYld8XziwhA==",
       "dev": true
     },
     "@feathersjs/errors": {
-      "version": "4.0.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.0.0-pre.5.tgz",
-      "integrity": "sha512-sLKAylx2dSScbLPdFNa+hBh+fRljYpNFdaewo6Eni5si9BscqiExVMzs3K3osQ5ue18xCMTBrdsmJNDIE7+gYw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.5.3.tgz",
+      "integrity": "sha512-yvy5k0X79yQBxNSmjxU8rxRrKD/YnMjqAWzT/LbJ41UIOsvRzo88pqFuNXTX8qbB90IPjtxgbSjuaxoiQZ7nmg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1"
@@ -116,15 +116,15 @@
       }
     },
     "@feathersjs/feathers": {
-      "version": "4.0.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.0.0-pre.5.tgz",
-      "integrity": "sha512-oyDPjvFO99pNbN16TcehWFswLiiuc/yNP7JwVtcTbh1gcxEJQABKTvKO547Ts1qdolKEBQBP4u+R8l1hdIx83w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.5.3.tgz",
+      "integrity": "sha512-1JcX2orsAatDLN6PKHsfUzA7CXyiBCJ4rV3CArUZIHuIiM2oDto47M3N7B46q9CoqzuXxBG3OtoFV1eb93vnsA==",
       "dev": true,
       "requires": {
-        "@feathersjs/commons": "^4.0.0-pre.5",
+        "@feathersjs/commons": "^4.5.3",
         "debug": "^4.1.1",
-        "events": "^3.0.0",
-        "uberproto": "^2.0.4"
+        "events": "^3.1.0",
+        "uberproto": "^2.0.6"
       },
       "dependencies": {
         "debug": {
@@ -141,19 +141,8 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "uberproto": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.4.tgz",
-          "integrity": "sha512-c/5xjTcztW9XVhrkCycHQRBIAxww5JpDKk/q0zc2tVdQn6ZQvnChWgLvQaWAT1Al5JvRyvloUI15ad41m6dYwg==",
-          "dev": true
         }
       }
-    },
-    "@types/graphql": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.2.tgz",
-      "integrity": "sha512-okXbUmdZFMO3AYBEJCcpJFPFDkKmIiZZBqWD5TmPtAv+GHfjD2qLZEI0PvZ8IWMU4ozoK2HV2lDxWjw4LbVlnw=="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -391,11 +380,6 @@
         }
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -461,6 +445,7 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       },
@@ -468,7 +453,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -1025,9 +1011,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
     },
     "execa": {
       "version": "1.0.0",
@@ -1056,9 +1042,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1072,81 +1058,63 @@
       "dev": true
     },
     "feathers-hooks-common": {
-      "version": "4.20.7",
-      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-4.20.7.tgz",
-      "integrity": "sha512-+9CXrj2FeDAOlDmU7MBdmYg72F+na17kss/97Vyus4zRbLJvuV2ky6Jto16NSJ906OsbYjHHXKIKzw1uPnlx3w==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-5.0.3.tgz",
+      "integrity": "sha512-Irw7mVecC2im9Pemr4yGyO8XXxFhlqn4rnsc5iSNMSmO78ta1QaHUfiZddmquA0u0KTFyk2crQK4mcHq8grzXA==",
       "requires": {
-        "@feathers-plus/batch-loader": "^0.3.0",
-        "@feathersjs/commons": "^1.4.0",
-        "@feathersjs/errors": "^3.3.0",
-        "@feathersjs/feathers": "^3.1.3",
-        "@types/graphql": "^14.0.4",
-        "ajv": "^5.5.2",
-        "debug": "^3.1.0",
-        "graphql": "^14.0.2",
-        "libphonenumber-js": "^1.6.8",
+        "@feathers-plus/batch-loader": "^0.3.6",
+        "@feathersjs/commons": "^4.5.3",
+        "@feathersjs/errors": "^4.5.3",
+        "@feathersjs/feathers": "^4.5.3",
+        "ajv": "^6.12.2",
+        "debug": "^4.1.1",
+        "graphql": "^15.0.0",
+        "lodash": "^4.17.15",
         "process": "0.11.10",
         "traverse": "^0.6.6"
       },
       "dependencies": {
         "@feathersjs/commons": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.4.tgz",
-          "integrity": "sha512-ZPpzyZA3CPfoa9AuFv3BJUI/ubzaaXixp8T/pqeMFPT6DOaU/6oF7lz1RxwimzfJNna4gy/HByt0EoLSI3BKWg=="
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.5.3.tgz",
+          "integrity": "sha512-LsiZ0jxh13TT6SOrDq5VYtdBCv0Vdvu4a5Wei/Dvd/daZHX6ERuH6iQtfh2f5hFwuydtd+Ch/2GlYld8XziwhA=="
         },
         "@feathersjs/errors": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.3.6.tgz",
-          "integrity": "sha512-VCohY/AQU13xYyZGl6rfdUgE+2bjaI76a4aEb6reIphHKgb4mnjYlg2PzS1/hcU1qUNi515kY9yQa5HsE7J1dQ==",
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-4.5.3.tgz",
+          "integrity": "sha512-yvy5k0X79yQBxNSmjxU8rxRrKD/YnMjqAWzT/LbJ41UIOsvRzo88pqFuNXTX8qbB90IPjtxgbSjuaxoiQZ7nmg==",
           "requires": {
-            "debug": "^4.0.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
+            "debug": "^4.1.1"
           }
         },
         "@feathersjs/feathers": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.3.1.tgz",
-          "integrity": "sha512-Mb7Maz03TIIksomXeInmXNb5ykxgsAyBCuJDQHK+oIDrDRR9m+ZbUrslCkMk/s0nr6cW5DmVbWz9s11SCXFW5A==",
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-4.5.3.tgz",
+          "integrity": "sha512-1JcX2orsAatDLN6PKHsfUzA7CXyiBCJ4rV3CArUZIHuIiM2oDto47M3N7B46q9CoqzuXxBG3OtoFV1eb93vnsA==",
           "requires": {
-            "@feathersjs/commons": "^4.0.0",
-            "debug": "^4.0.0",
-            "events": "^3.0.0",
-            "uberproto": "^2.0.2"
-          },
-          "dependencies": {
-            "@feathersjs/commons": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-4.0.0.tgz",
-              "integrity": "sha512-hyCLse4RiNt7WLPQ0KSudjoVnwiRykhYzIZdtDon9i2usPaoYkFw/fEYZrkE5HVB+sUTwphZoZ1oOntRk1MShg=="
-            },
-            "debug": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
+            "@feathersjs/commons": "^4.5.3",
+            "debug": "^4.1.1",
+            "events": "^3.1.0",
+            "uberproto": "^2.0.6"
           }
         },
         "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
+            "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -1157,21 +1125,21 @@
       }
     },
     "feathers-memory": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/feathers-memory/-/feathers-memory-4.0.0.tgz",
-      "integrity": "sha512-atyq5t+YTQD0Vfe4lh1hUHD7kzx5uEIktSCOZmM7khYqAD4KwzYexIfKb6mFdk8jgFIoYLH+kryJojPyxh61sg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/feathers-memory/-/feathers-memory-4.1.0.tgz",
+      "integrity": "sha512-tR8DFqLsSk2w7tpSdHjA5RgPHTu3X5R3L3Kob2K+E3b/Q5cDkI6AYQarDQOiwekAyqxkkp/fm7Fg0qYdu4Ua6Q==",
       "dev": true,
       "requires": {
-        "@feathersjs/adapter-commons": "^4.0.0-pre.4",
-        "@feathersjs/commons": "^4.0.0-pre.4",
-        "@feathersjs/errors": "^4.0.0-pre.4",
+        "@feathersjs/adapter-commons": "^4.3.6",
+        "@feathersjs/commons": "^4.3.0",
+        "@feathersjs/errors": "^4.3.4",
         "sift": "^8.5.0"
       },
       "dependencies": {
         "sift": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/sift/-/sift-8.5.0.tgz",
-          "integrity": "sha512-IdHwlvlDbHYmcPYOfkU89Qo29cPR7fLM0htfeUP9YxeU213oKYH/6d416z+vFj6ArCsH+AzQQ8/rd1TIzRE7LQ==",
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/sift/-/sift-8.5.1.tgz",
+          "integrity": "sha512-um2rEdXrc4YcRMzIliuip4i2o92mJONh5W1VD9vJlm1e0apVqMK4P2ZUijz8BIe1/oYLWmXwXaKFM+fOaO3Ysg==",
           "dev": true
         }
       }
@@ -1351,12 +1319,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.4.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-      "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.1.0.tgz",
+      "integrity": "sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q=="
     },
     "growl": {
       "version": "1.10.5",
@@ -1728,11 +1693,6 @@
         }
       }
     },
-    "iterall": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1756,9 +1716,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1795,22 +1755,6 @@
         "type-check": "~0.3.2"
       }
     },
-    "libphonenumber-js": {
-      "version": "1.7.20",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.20.tgz",
-      "integrity": "sha512-rjgSW5SEzkFwm84eXGjzZSOjLnzewcjQb8NwELXKki08CqkPi8ubqPzMheONEr2trcwieAIGWQt90MdIt4gfiA==",
-      "requires": {
-        "minimist": "^1.2.0",
-        "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -1842,10 +1786,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -2760,8 +2703,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "react-is": {
       "version": "16.8.6",
@@ -2871,11 +2813,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -2904,9 +2841,9 @@
       "dev": true
     },
     "sift": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-8.5.0.tgz",
-      "integrity": "sha512-IdHwlvlDbHYmcPYOfkU89Qo29cPR7fLM0htfeUP9YxeU213oKYH/6d416z+vFj6ArCsH+AzQQ8/rd1TIzRE7LQ==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-11.1.8.tgz",
+      "integrity": "sha512-QoNDdWFzFrtoNdYeJeDjhceLiuHOGlLacVxE7Y5QX/teBeYBWRM6s4RatraBoRvEsoDr/bsjeCmEH0hSHCJChQ==",
       "dev": true
     },
     "signal-exit": {
@@ -3169,9 +3106,9 @@
       "dev": true
     },
     "uberproto": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.4.tgz",
-      "integrity": "sha512-c/5xjTcztW9XVhrkCycHQRBIAxww5JpDKk/q0zc2tVdQn6ZQvnChWgLvQaWAT1Al5JvRyvloUI15ad41m6dYwg=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-2.0.6.tgz",
+      "integrity": "sha512-68H97HffZoFaa3HFtpstahWorN9dSp5uTU6jo3GjIQ6JkJBR3hC2Nx/e/HFOoYHdUyT/Z1MRWfxN1EiQJZUyCQ=="
     },
     "uglify-js": {
       "version": "3.6.0",
@@ -3203,7 +3140,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -3296,20 +3232,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/test/shallow-populate.test.js
+++ b/test/shallow-populate.test.js
@@ -8,14 +8,18 @@ const services = {
     store: {
       111: { id: '111', name: 'My Monkey and Me' },
       222: { id: '222', name: 'I forgot why I love you' },
-      333: { id: '333', name: 'If I were a banana...' }
+      333: { id: '333', name: 'If I were a banana...' },
+      444: { id: 444, name: 'One, two, three, one, two, three, drink' },
+      555: { id: 555, name: 'Im gonna live like tomorrow doesnt exist' },
+      666: { id: 666, name: 'I feel the love, feel the love' }
     }
   }),
   users: memory({
     store: {
       11: { id: '11', name: 'Joe Bloggs', postsId: ['111'] },
       22: { id: '22', name: 'Jane Bloggs', postsId: '333' },
-      33: { id: '33', name: 'John Smith', postsId: ['111', '222'] }
+      33: { id: '33', name: 'John Smith', postsId: ['111', '222'] },
+      44: { id: 44, name: 'Muhammad Li', postsId: [444, '555'] }
     },
     matcher: query => {
       return items => {
@@ -29,7 +33,10 @@ const services = {
     store: {
       ts1: { id: 'ts1', name: 'Task Set 1' },
       ts2: { id: 'ts2', name: 'Task Set 2' },
-      ts3: { id: 'ts3', name: 'Task Set 3' }
+      ts3: { id: 'ts3', name: 'Task Set 3' },
+      4: { id: 4, name: 'Task Set 4' },
+      5: { id: 5, name: 'Task Set 5' },
+      ts6: { id: 'ts6', name: 'Task Set 6' }
     }
   }),
   tasks: memory({
@@ -37,16 +44,20 @@ const services = {
       task1: { id: 'task1', name: 'Task 1 - belongs with TaskSet1', taskSet: { taskSetId: 'ts1' } },
       task2: { id: 'task2', name: 'Task 2 - belongs with TaskSet2', taskSet: { taskSetId: 'ts2' } },
       task3: { id: 'task3', name: 'Task 3 - belongs with TaskSet2', taskSet: { taskSetId: 'ts2' } },
-      task4: { id: 'task4', name: 'Task 3 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
-      task5: { id: 'task5', name: 'Task 3 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
-      task6: { id: 'task6', name: 'Task 3 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } }
+      task4: { id: 'task4', name: 'Task 4 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
+      task5: { id: 'task5', name: 'Task 5 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
+      task6: { id: 'task6', name: 'Task 6 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
+      7: { id: 7, name: 'Task 7 - belongs with TaskSet4', taskSet: { taskSetId: 4 } },
+      task8: { id: 'task8', name: 'Task 8 - belongs with TaskSet5', taskSet: { taskSetId: 5 } },
+      9: { id: 9, name: 'Task 9 - belongs with TaskSet6', taskSet: { taskSetId: 'ts6' } }
     }
   }),
   comments: memory({
     store: {
       11111: { id: '11111', name: 'The Best Sounds This Summer', postsId: ['222'] },
       22222: { id: '22222', name: 'Chillstation', postsId: ['333'] },
-      33333: { id: '33333', name: 'Hard Hitting Bass', postsId: ['111', '222', '333'] }
+      33333: { id: '33333', name: 'Hard Hitting Bass', postsId: ['111', '222', '333'] },
+      44444: { id: 44444, name: 'As long as skies are blue', postsId: ['111', 444, '555'] }
     },
     matcher: query => {
       return items => {
@@ -60,13 +71,17 @@ const services = {
     store: {
       1111: { id: '1111', name: 'Trombones' },
       2222: { id: '2222', name: 'Trumpets' },
-      3333: { id: '3333', name: 'Drums' }
+      3333: { id: '3333', name: 'Drums' },
+      4444: { id: 4444, name: 'Guitars' },
+      5555: { id: 5555, name: 'Violins' }
     }
   }),
   orgs: memory({
     store: {
       org1: { id: 'org1', name: 'Southern Utah', memberCount: 21 },
-      org2: { id: 'org2', name: 'Northern Utah', memberCount: 99 }
+      org2: { id: 'org2', name: 'Northern Utah', memberCount: 99 },
+      3: { id: 3, name: 'Northern Arizona', memberCount: 42 },
+      4: { id: 4, name: 'Southern Arizona', memberCount: 23 }
     }
   }),
   environments: memory({
@@ -91,6 +106,27 @@ const services = {
         orgs: [
           { orgId: 'org2', orgName: 'Northern Utah' }
         ]
+      },
+      4: {
+        id: 4,
+        name: 'Grand Canyon National Park',
+        orgs: [
+          { orgId: 3, orgName: 'Northern Arizona' }
+        ]
+      },
+      5: {
+        id: '5',
+        name: 'Organ Pipe Cactus National Monument',
+        orgs: [
+          { orgId: 4, orgName: 'Southern Arizona' }
+        ]
+      },
+      6: {
+        id: 6,
+        name: 'Antelope Canyon',
+        orgs: [
+          { orgId: 'org1', orgName: 'Southern Utah' }
+        ]
       }
     }
   })
@@ -105,7 +141,7 @@ describe('shallowPopulate hook', function () {
       data: {
         id: '11',
         name: 'Dumb Stuff',
-        postsId: ['111', '222', '333']
+        postsId: ['111', '222', '333', 444, 555, '666']
       }
     }
 
@@ -137,7 +173,7 @@ describe('shallowPopulate hook', function () {
       data: {
         id: '11',
         name: 'Dumb Stuff',
-        postsId: ['111', '222', '333']
+        postsId: ['111', '222', '333', 444, 555, '666']
       }
     }
 
@@ -182,7 +218,7 @@ describe('shallowPopulate hook', function () {
         id: '11',
         name: 'Dumb Stuff',
         meta: {
-          postsId: ['111', '222', '333']
+          postsId: ['111', '222', '333', 444, 555, '666']
         }
       }
     }
@@ -327,7 +363,7 @@ describe('shallowPopulate hook', function () {
             data: {
               id: '11',
               name: 'Dumb Stuff',
-              postIds: ['111', '222']
+              postIds: ['111', '222', 444, '555']
             }
           }
 
@@ -403,7 +439,7 @@ describe('shallowPopulate hook', function () {
               id: '11',
               name: 'Dumb Stuff',
               meta: {
-                postsId: ['111']
+                postsId: ['111', 444]
               }
             }
           }
@@ -441,7 +477,7 @@ describe('shallowPopulate hook', function () {
             data: {
               id: '11',
               name: 'Dumb Stuff',
-              postsId: ['111', '222', '333']
+              postsId: ['111', '222', '333', 444, 555, '666']
             }
           }
 
@@ -565,7 +601,7 @@ describe('shallowPopulate hook', function () {
               id: '11',
               name: 'Dumb Stuff',
               postIds: '111',
-              tagIds: ['1111']
+              tagIds: ['1111', 4444]
             }
           }
 
@@ -615,8 +651,8 @@ describe('shallowPopulate hook', function () {
             data: {
               id: '11',
               name: 'Dumb Stuff',
-              postIds: ['111', '222'],
-              tagIds: ['1111', '3333']
+              postIds: ['111', '222', 444],
+              tagIds: ['1111', '3333', 4444]
             }
           }
 
@@ -665,7 +701,7 @@ describe('shallowPopulate hook', function () {
             data: {
               id: '11',
               name: 'Dumb Stuff',
-              tagIds: ['1111', '3333']
+              tagIds: ['1111', '3333', 4444]
             }
           }
 
@@ -675,7 +711,7 @@ describe('shallowPopulate hook', function () {
             .then(context => {
               const { data } = context
               assert(!data.posts, 'posts should have not been populated')
-              assert(data.tags.length === 2, 'tags have been populated')
+              assert(data.tags.length === 3, 'tags have been populated')
               done()
             })
             .catch(done)
@@ -713,8 +749,8 @@ describe('shallowPopulate hook', function () {
               id: '11',
               name: 'Dumb Stuff',
               meta: {
-                postsId: ['111', '222', '333'],
-                tagIds: ['1111', '3333']
+                postsId: ['111', '222', '333', 444],
+                tagIds: ['1111', '3333', 4444]
               }
             }
           }
@@ -762,8 +798,8 @@ describe('shallowPopulate hook', function () {
             data: {
               id: '11',
               name: 'Dumb Stuff',
-              postsId: ['111', '222', '333'],
-              tagIds: ['1111', '3333']
+              postsId: ['111', '222', '333', 444],
+              tagIds: ['1111', '3333', 4444]
             }
           }
 
@@ -852,7 +888,7 @@ describe('shallowPopulate hook', function () {
               {
                 id: '11',
                 name: 'Dumb Stuff',
-                postIds: ['111', '222']
+                postIds: ['111', '222', 444]
               },
               {
                 id: '22',
@@ -862,7 +898,7 @@ describe('shallowPopulate hook', function () {
               {
                 id: '33',
                 name: 'Some Stuff',
-                postIds: ['111']
+                postIds: ['111', 444]
               }
             ]
           }
@@ -907,12 +943,17 @@ describe('shallowPopulate hook', function () {
               {
                 id: '11',
                 name: 'Dumb Stuff',
-                postIds: ['111', '222']
+                postIds: ['111', '222', 444]
               },
               {
                 id: '22',
                 name: 'Smart Stuff',
-                postIds: ['222', '111']
+                postIds: ['222', '111', 444]
+              },
+              {
+                id: 44,
+                name: 'Just Stuff',
+                postIds: [444, 111, '222']
               }
             ]
           }
@@ -956,11 +997,16 @@ describe('shallowPopulate hook', function () {
               {
                 id: '11',
                 name: 'Dumb Stuff',
-                tagIds: ['1111', '3333']
+                tagIds: ['1111', '3333', 4444]
               },
               {
                 id: '22',
                 name: 'Smart Stuff'
+              },
+              {
+                id: 44,
+                name: 'Just Stuff',
+                tagIds: [4444]
               }
             ]
           }
@@ -970,7 +1016,7 @@ describe('shallowPopulate hook', function () {
           shallowPopulate(context)
             .then(context => {
               const { data } = context
-              assert(data[0].tags.length === 2, 'tags have been populated')
+              assert(data[0].tags.length === 3, 'tags have been populated')
               assert(!data[1].tags, 'tags have not been populated')
               done()
             })
@@ -1000,14 +1046,21 @@ describe('shallowPopulate hook', function () {
                 id: '11',
                 name: 'Dumb Stuff',
                 meta: {
-                  postsId: ['111', '333']
+                  postsId: ['111', '333', 444]
                 }
               },
               {
                 id: '22',
                 name: 'Dumb Stuff',
                 meta: {
-                  postsId: ['222', '333', '111']
+                  postsId: ['222', '333', '111', 555]
+                }
+              },
+              {
+                id: 44,
+                name: 'Integer Stuff',
+                meta: {
+                  postsId: ['222', 555]
                 }
               }
             ]
@@ -1018,8 +1071,8 @@ describe('shallowPopulate hook', function () {
           shallowPopulate(context)
             .then(context => {
               const { data } = context
-              assert(data[0].meta.posts.length === 2, 'data[0] posts should have been populated')
-              assert(data[1].meta.posts.length === 3, 'data[0] posts should have been populated')
+              assert(data[0].meta.posts.length === 3, 'data[0] posts should have been populated')
+              assert(data[1].meta.posts.length === 4, 'data[0] posts should have been populated')
               done()
             })
             .catch(done)
@@ -1048,12 +1101,12 @@ describe('shallowPopulate hook', function () {
               {
                 id: '11',
                 name: 'Dumb Stuff',
-                postsId: ['111', '222']
+                postsId: ['111', '222', 444, '555']
               },
               {
                 id: '22',
                 name: 'Smart Stuff',
-                postsId: ['333']
+                postsId: ['333', 444, '555']
               }
             ]
           }
@@ -1064,8 +1117,8 @@ describe('shallowPopulate hook', function () {
             .then(context => {
               const { data } = context
 
-              assert(data[0].posts.length === 2, 'data[0] should have correct posts data')
-              assert(data[1].posts.length === 1, 'data[1] should have correct posts data')
+              assert(data[0].posts.length === 3, 'data[0] should have correct posts data')
+              assert(data[1].posts.length === 2, 'data[1] should have correct posts data')
 
               done()
             })
@@ -1099,6 +1152,10 @@ describe('shallowPopulate hook', function () {
               {
                 id: '222',
                 name: 'I forgot why I love you'
+              },
+              {
+                id: 444,
+                name: 'One, two, three, one, two, three, drink'
               }
             ]
           }
@@ -1154,13 +1211,19 @@ describe('shallowPopulate hook', function () {
                 id: '11',
                 name: 'Dumb Stuff',
                 postIds: '111',
-                tagIds: ['1111', '3333']
+                tagIds: ['1111', '3333', 4444]
               },
               {
                 id: '22',
                 name: 'Smart Stuff',
                 postIds: '222',
                 tagIds: ['1111']
+              },
+              {
+                id: 33,
+                name: 'Just Stuff',
+                postIds: 444,
+                tagIds: ['1111', 4444]
               }
             ]
           }
@@ -1219,13 +1282,13 @@ describe('shallowPopulate hook', function () {
               {
                 id: '11',
                 name: 'Dumb Stuff',
-                postIds: ['111', '222'],
-                tagIds: ['1111', '3333']
+                postIds: ['111', '222', 444],
+                tagIds: ['1111', '3333', 4444]
               },
               {
                 id: '22',
                 name: 'Smart Stuff',
-                postIds: ['222'],
+                postIds: ['222', 444],
                 tagIds: ['1111']
               }
             ]
@@ -1284,12 +1347,12 @@ describe('shallowPopulate hook', function () {
               {
                 id: '11',
                 name: 'Dumb Stuff',
-                postIds: ['111', '222', '333']
+                postIds: ['111', '222', '333', 444]
               },
               {
                 id: '22',
                 name: 'Smart Stuff',
-                postIds: ['111', '333']
+                postIds: ['111', '333', 555]
               }
             ]
           }
@@ -1299,10 +1362,10 @@ describe('shallowPopulate hook', function () {
           shallowPopulate(context)
             .then(context => {
               const { data } = context
-              assert(data[0].posts.length === 3, 'posts have been populated')
+              assert(data[0].posts.length === 4, 'posts have been populated')
               assert(!data[0].tags, 'tags have not been populated')
               assert(!data[1].tags, 'tags have not been populated')
-              assert(data[1].posts.length === 2, 'posts have been populated')
+              assert(data[1].posts.length === 3, 'posts have been populated')
               done()
             })
             .catch(done)
@@ -1417,7 +1480,7 @@ describe('shallowPopulate hook', function () {
               assert(data[0].comments.length === 2, 'data[0] should have correct comments data')
 
               assert(data[1].users.length === 2, 'data[1] should have correct users data')
-              assert(data[1].comments.length === 1, 'data[1] should have correct comments data')
+              assert(data[1].comments.length === 2, 'data[1] should have correct comments data')
 
               done()
             })
@@ -2655,6 +2718,10 @@ describe('shallowPopulate hook', function () {
               {
                 id: '111',
                 name: 'My Monkey and Me'
+              },
+              {
+                id: 444,
+                name: 'One, two, three, one, two, three, drink'
               }
             ]
           }
@@ -2669,7 +2736,7 @@ describe('shallowPopulate hook', function () {
               assert(result[0].comments.length === 2, 'result[0] should have correct comments data')
 
               assert(result[1].users.length === 2, 'result[1] should have correct users data')
-              assert(result[1].comments.length === 1, 'result[1] should have correct comments data')
+              assert(result[1].comments.length === 2, 'result[1] should have correct comments data')
 
               done()
             })
@@ -2699,7 +2766,8 @@ describe('shallowPopulate hook', function () {
             result: [
               { id: 'ts1', name: 'Task Set 1' },
               { id: 'ts2', name: 'Task Set 2' },
-              { id: 'ts3', name: 'Task Set 3' }
+              { id: 'ts3', name: 'Task Set 3' },
+              { id: 4, name: 'Task Set 4' }
             ]
           }
 
@@ -2712,6 +2780,7 @@ describe('shallowPopulate hook', function () {
               assert(result[0].tasks.length === 1, 'result[0] should have correct users data')
               assert(result[1].tasks.length === 2, 'result[1] should have correct comments data')
               assert(result[2].tasks.length === 3, 'result[2] should have correct comments data')
+              assert(result[3].tasks.length === 1, 'result[3] should have correct comments data')
 
               done()
             })
@@ -2743,9 +2812,10 @@ describe('shallowPopulate hook', function () {
               { id: 'task1', name: 'Task 1 - belongs with TaskSet1', taskSet: { taskSetId: 'ts1' } },
               { id: 'task2', name: 'Task 2 - belongs with TaskSet2', taskSet: { taskSetId: 'ts2' } },
               { id: 'task3', name: 'Task 3 - belongs with TaskSet2', taskSet: { taskSetId: 'ts2' } },
-              { id: 'task4', name: 'Task 3 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
-              { id: 'task5', name: 'Task 3 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
-              { id: 'task6', name: 'Task 3 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } }
+              { id: 'task4', name: 'Task 4 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
+              { id: 'task5', name: 'Task 5 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
+              { id: 'task6', name: 'Task 6 - belongs with TaskSet3', taskSet: { taskSetId: 'ts3' } },
+              { id: 7, name: 'Task 7 - belongs with TaskSet4', taskSet: { taskSetId: 4 } }
             ]
           }
 
@@ -2787,7 +2857,8 @@ describe('shallowPopulate hook', function () {
             params: {},
             result: [
               { id: 'org1', name: 'Southern Utah', memberCount: 21 },
-              { id: 'org2', name: 'Northern Utah', memberCount: 99 }
+              { id: 'org2', name: 'Northern Utah', memberCount: 99 },
+              { id: 3, name: 'Northern Arizona', memberCount: 42 }
             ]
           }
 
@@ -2799,7 +2870,7 @@ describe('shallowPopulate hook', function () {
 
               result.forEach(r => {
                 if (r.id === 'org1') {
-                  assert(r.envs.length === 2, 'org1 should have two environments')
+                  assert(r.envs.length === 3, 'org1 should have two environments')
                   assert(r.envs[0].orgs[0].orgId === 'org1', 'should have at least one environment populated')
                 } else if (r.id === 'org2') {
                   assert(r.envs.length === 1, 'org2 should have one environment')


### PR DESCRIPTION
### What was the problem:
`feathers-shallow-populate` was not working with ids as `numbers` which is the default behaviour for `feathers-sequelize`.

### Why it was not working?
The ids were stored by `Object.keys()` by which the ids become `strings`. This way `{ query: { [i.keyThere]: { $in: keysHere } } }` queries for strings.

### How is it solved?
The utility-function `mapData` is replaced by `mapDataWithId` which stores the key as seperate val. So the datatype won't get lost.

Tests added for evidence.