### PR TITLE
Fix single relation null

### DIFF
--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -280,7 +280,7 @@ function getRelatedItems (ids, relatedItems, include, params) {
   const limit = _get(params, 'query.$limit', Math.max)
   ids = [].concat(ids || [])
   let skipped = 0
-  let itemOrItems = (asArray) ? [] : {}
+  let itemOrItems = (asArray) ? [] : undefined
 
   let isDone = false
   for (let i = 0, n = relatedItems.length; i < n; i++) {

--- a/lib/shallow-populate.js
+++ b/lib/shallow-populate.js
@@ -257,12 +257,14 @@ function setItems (data, include, params, response) {
     if (keyHere !== undefined) {
       if (Array.isArray(keyHere)) {
         if (!asArray) {
-          _set(item, nameAs, getRelatedItems(keyHere[0], relatedItems, include, params))
+          const items = getRelatedItems(keyHere[0], relatedItems, include, params)
+          if (items !== undefined) { _set(item, nameAs, items) }
         } else {
           _set(item, nameAs, getRelatedItems(keyHere, relatedItems, include, params))
         }
       } else {
-        _set(item, nameAs, getRelatedItems(keyHere, relatedItems, include, params))
+        const items = getRelatedItems(keyHere, relatedItems, include, params)
+        if (items !== undefined) { _set(item, nameAs, items) }
       }
     }
   })

--- a/test/shallow-populate.test.js
+++ b/test/shallow-populate.test.js
@@ -277,7 +277,8 @@ describe('populating thing', () => {
               service: 'posts',
               nameAs: 'posts',
               keyHere: 'postsId',
-              keyThere: 'id'
+              keyThere: 'id',
+              asArray: false
             }
           }
           const context = {

--- a/test/shallow-populate.test.js
+++ b/test/shallow-populate.test.js
@@ -304,6 +304,43 @@ describe('populating thing', () => {
         }
       })
 
+      it('does nothing if keyHere of related item is null', async () => {
+        for (const { type, dataResult } of beforeAfter) {
+          const options = {
+            include: {
+              // from: 'users',
+              service: 'posts',
+              nameAs: 'posts',
+              keyHere: 'postsId',
+              keyThere: 'id',
+              asArray: false
+            }
+          }
+          const context = {
+            app: {
+              service (path) {
+                return services[path]
+              }
+            },
+            method: 'create',
+            type,
+            params: {},
+            [dataResult]: {
+              id: '11',
+              name: 'Dumb Stuff',
+              postsId: null
+            }
+          }
+
+          const shallowPopulate = makePopulate(options)
+
+          const response = await shallowPopulate(context)
+          const result = response[dataResult]
+
+          assert(!result.posts, `${type}: post should have not been populated`)
+        }
+      })
+
       it('populates from local keys dot notation', async () => {
         for (const { type, dataResult } of beforeAfter) {
           const options = {

--- a/test/shallow-populate.test.js
+++ b/test/shallow-populate.test.js
@@ -338,7 +338,7 @@ describe('populating thing', () => {
           const response = await shallowPopulate(context)
           const result = response[dataResult]
 
-          assert(!result.posts, `${type}: post should have not been populated`)
+          assert(!Object.prototype.hasOwnProperty.call(result, 'posts'), `${type}: post should have not been populated`)
         }
       })
 


### PR DESCRIPTION
### Summary

Fixes an error, where getRelatedItems returned an empty object instead of undefined, when keyHere is null instead of undefined.

This fix is also important for feathers-graph-populate, where i initially found the issue.

Thanks to @fratzinger for the help! 